### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Vercel
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kev7n11f/themebotpark/security/code-scanning/1](https://github.com/kev7n11f/themebotpark/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow (just below the `name` field), so it applies to all jobs unless overridden. Since the workflow only needs to check out code and deploy using secrets (and does not need to write to the repository), the minimal required permission is `contents: read`. This change should be made at the top of `.github/workflows/deploy.yml`, after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
